### PR TITLE
Gitlab Profile Widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,47 +1,25 @@
-# Byte-compiled / optimized / DLL files
-__pycache__/
-*.py[cod]
+*~
+*.log
+*.pot
+*.pyc
+*.pyo
+*.egg*
+local_settings.py
+project_cfg.py
 
-# C extensions
-*.so
+*.swp
+*.sqlite3
+*.db
+.DS_Store
+.vagrant
 
-# Distribution / packaging
-.Python
-env/
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
+ext/
 *.egg-info/
-.installed.cfg
-*.egg
+dist/
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
+# Coverage
 .coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*,cover
+coverage_report/
 
 # Translations
 *.pot
@@ -49,8 +27,8 @@ coverage.xml
 # Django stuff:
 *.log
 
-# Sphinx documentation
-docs/_build/
+# Open Build System
+.obs/
 
-# PyBuilder
-target/
+# Documentation build
+docs/build

--- a/src/colab_gitlab/apps.py
+++ b/src/colab_gitlab/apps.py
@@ -8,7 +8,7 @@ from colab_gitlab.tasks import handling_method
 class GitlabPluginAppConfig(ColabPluginAppConfig):
     name = 'colab_gitlab'
     verbose_name = 'Gitlab Plugin'
-    short_name = 'gitlab'
+    short_name = 'colab_gitlab'
 
     signals_list = ['gitlab_create_project']
 

--- a/src/colab_gitlab/profile/diazo.xml
+++ b/src/colab_gitlab/profile/diazo.xml
@@ -1,0 +1,36 @@
+<rules
+    xmlns="http://namespaces.plone.org/diazo"
+    xmlns:css="http://namespaces.plone.org/diazo/css"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+    <xsl:variable name="username" select="str:replace(//a/@href[(contains(., '/gitlab/u/'))], '/gitlab/u/', '')" />
+    <xsl:template match="a/@href[(contains(., '/profile/'))]">
+        <xsl:attribute name="href">/account/<xsl:value-of select="$username"/>/edit?code=<xsl:value-of select="."/>/</xsl:attribute>
+    </xsl:template>
+    <xsl:template match="form/@action[(contains(., '/gitlab/'))]">
+        <xsl:attribute name="action">/account/<xsl:value-of select="$username"/>/edit?code=<xsl:value-of select="."/>/</xsl:attribute>
+    </xsl:template>
+
+    <!-- Drop colab stuff -->
+    <drop css:theme="nav.navbar-fixed-top" />
+    <drop css:theme="div.footer" />
+
+    <!-- Drop unused tabs on gitlab -->
+    <drop content="div[@class='container']/ul/li[1]" />
+    <drop content="div[@class='container']/ul/li[3]" />
+    <drop content="div[@class='container']/ul/li[4]" />
+    <drop content="div[@class='container']/ul/li[7]" />
+    <drop content="fieldset[@class='update-username']" />
+
+    <before theme-children="/html/head" content-children="/html/head" />
+    <before css:theme-children="#main-content" css:content-children="body" />
+
+    <merge attributes="class" css:theme="body" css:content="body" /> 
+
+    <!-- Add gitlab properties -->
+    <merge attributes="data-page" css:theme="body" css:content="body" />
+    <merge attributes="data-project-id" css:theme="body" css:content="body" />
+
+    <drop css:content="#top-panel" />
+    <drop css:content=".navbar-gitlab" />
+</rules>

--- a/src/colab_gitlab/templates/proxy/gitlab_profile.html
+++ b/src/colab_gitlab/templates/proxy/gitlab_profile.html
@@ -1,0 +1,49 @@
+
+{% load static from staticfiles %}
+
+{% block head_css %}
+<style>
+  /* Reset left and with for .modal-dialog style (like gitlab does), 
+     the bootstrap.css one makes it small */
+  @media screen and (min-width: 768px) {
+    .modal-dialog {
+      left: auto;
+      width: auto;
+    }
+  }
+
+  div#main-content div.container {
+    width: 1110px;
+  }
+  div#main-content div.flash-container{
+    width: 85%;
+  }
+  #breadcrumbs {
+    border: 0 !important;
+  }
+
+  #right-top-nav {
+    margin-right: 5em !important;
+  }
+</style>
+{% endblock %}
+
+{% block head_js %}
+<script>jQuery.noConflict();</script>
+{% endblock %}
+
+<div id="main-content"></div>
+<script type="text/javascript">
+  jQuery(function(){
+    // bootstrap.css forces .hide {display:none!important}, and this makes
+    // gitlab .hide elements NEVER have a display:block, so
+    // instead of editing bootstrap.css, we just removed '.hide' css class and
+    // toggled
+    jQuery('.hide').removeClass('hide').css('display', 'none');
+  });
+
+  // Extremelly ugly solutions to add Colab's CSRF token to Gitlab forms
+  // add CSRF token to HTTP header***
+  jQuery('div#code form').append(jQuery("input[name='csrfmiddlewaretoken']"));
+  $('a.delete-key').attr('data-method', 'delete\" type=\"hidden\" /> <input name=\"csrfmiddlewaretoken\" value=\"' + jQuery("input[name='csrfmiddlewaretoken']").val());
+</script>

--- a/src/colab_gitlab/views.py
+++ b/src/colab_gitlab/views.py
@@ -1,4 +1,5 @@
-import os, sys
+import os
+import sys
 from colab.plugins.views import ColabProxyView
 
 

--- a/src/colab_gitlab/views.py
+++ b/src/colab_gitlab/views.py
@@ -1,7 +1,21 @@
-
+import os, sys
 from colab.plugins.views import ColabProxyView
 
 
 class GitlabProxyView(ColabProxyView):
     app_label = 'colab_gitlab'
     diazo_theme_template = 'proxy/gitlab.html'
+
+
+class GitlabProfileProxyView(ColabProxyView):
+    app_label = 'colab_gitlab'
+    diazo_theme_template = 'proxy/gitlab_profile.html'
+
+    @property
+    def diazo_rules(self):
+        child_class_file = sys.modules[self.__module__].__file__
+        app_path = os.path.abspath(os.path.dirname(child_class_file))
+        diazo_path = os.path.join(app_path, 'profile/diazo.xml')
+
+        self.log.debug("diazo_rules: %s", diazo_path)
+        return diazo_path

--- a/src/colab_gitlab/widgets.py
+++ b/src/colab_gitlab/widgets.py
@@ -1,5 +1,5 @@
 from .views import GitlabProxyView, GitlabProfileProxyView
-from colab.plugins.utils.widget_manager import Widget
+from colab.widgets.widget_manager import Widget
 from django.utils.safestring import mark_safe
 
 

--- a/src/colab_gitlab/widgets.py
+++ b/src/colab_gitlab/widgets.py
@@ -1,0 +1,33 @@
+from .views import GitlabProxyView, GitlabProfileProxyView
+from colab.plugins.utils.widget_manager import Widget
+from django.utils.safestring import mark_safe
+
+
+class GitlabProfileWidget(GitlabProxyView, Widget):
+    identifier = 'code'
+    name = 'Gitlab Profile'
+    default_url = '/gitlab/profile/account'
+
+    def get_body(self):
+        start = self.content.find('<body')
+        start = self.content.find('>', start)
+        end = self.content.find('</body>')
+
+        if -1 in [start, end]:
+            return ''
+
+        body = self.content[start + len('>'):end]
+        return mark_safe(body)
+
+    def generate_content(self, request):
+        requested_url = request.GET.get('code', self.default_url)
+        g = GitlabProfileProxyView()
+        r = g.dispatch(request, requested_url)
+
+        if r.status_code == 302:
+            location = r.get('Location')
+            requested_url = location[location.find('/{}/'.format(self.app_label)):]
+            request.method = 'GET'
+            r = g.dispatch(request, requested_url)
+
+        self.content = r.content

--- a/src/colab_gitlab/widgets.py
+++ b/src/colab_gitlab/widgets.py
@@ -26,7 +26,8 @@ class GitlabProfileWidget(GitlabProxyView, Widget):
 
         if r.status_code == 302:
             location = r.get('Location')
-            requested_url = location[location.find('/{}/'.format(self.app_label)):]
+            requested_url = \
+                location[location.find('/{}/'.format(self.app_label)):]
             request.method = 'GET'
             r = g.dispatch(request, requested_url)
 


### PR DESCRIPTION
Create file /etc/colab/widget_settings.py

```python
from colab.widgets.widget_manager import WidgetManager                     
from colab_gitlab.widgets import GitlabProfileWidget                             

WidgetManager.register_widget('profile', GitlabProfileWidget())
```

In order to active the gitlab widget on the Edit Profile option.
To test you need a working gitlab and the widget system merge solved.