### PR TITLE
Fix KeyError when user not logged in gitlab

### DIFF
--- a/src/colab_gitlab/locale/pt_BR/LC_MESSAGES/django.po
+++ b/src/colab_gitlab/locale/pt_BR/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-03 18:50+0000\n"
+"POT-Creation-Date: 2016-03-14 12:21+0000\n"
 "PO-Revision-Date: Mon Sep  7 12:24:23 BRT 2015 \n"
 "Last-Translator:  Macártur de Sousa Carvalho <macartur.sc@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,93 +16,112 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: filters.py:7
+#: src/colab_gitlab/filters.py:7
 msgid "Projects"
 msgstr "Projetos"
 
-#: filters.py:10 filters.py:22 filters.py:35 filters.py:48
+#: src/colab_gitlab/filters.py:10 src/colab_gitlab/filters.py:22
+#: src/colab_gitlab/filters.py:35 src/colab_gitlab/filters.py:48
 msgid "Name"
 msgstr "Nome"
 
-#: filters.py:13 filters.py:25 filters.py:38 filters.py:51
+#: src/colab_gitlab/filters.py:13 src/colab_gitlab/filters.py:25
+#: src/colab_gitlab/filters.py:38 src/colab_gitlab/filters.py:51
 msgid "Description"
 msgstr "Descrição"
 
-#: filters.py:19
+#: src/colab_gitlab/filters.py:19
 msgid "Merge Requests"
 msgstr "Envio de Contribuições"
 
-#: filters.py:28 filters.py:41
+#: src/colab_gitlab/filters.py:28 src/colab_gitlab/filters.py:41
 msgid "State"
 msgstr "Estado"
 
-#: filters.py:32
+#: src/colab_gitlab/filters.py:32
 msgid "Issues"
 msgstr "Tíquetes"
 
-#: filters.py:45
+#: src/colab_gitlab/filters.py:45
 msgid "Comments"
 msgstr "Comentários"
 
-#: models.py:28
+#: src/colab_gitlab/models.py:28
 msgid "Gitlab Project"
 msgstr "Projeto"
 
-#: models.py:29
+#: src/colab_gitlab/models.py:29
 msgid "Gitlab Projects"
 msgstr "Projetos"
 
-#: models.py:55
+#: src/colab_gitlab/models.py:55
 msgid "Gitlab Group"
 msgstr "Grupo"
 
-#: models.py:56
+#: src/colab_gitlab/models.py:56
 msgid "Gitlab Groups"
 msgstr "Grupos"
 
-#: models.py:92
+#: src/colab_gitlab/models.py:92
 msgid "Gitlab Merge Request"
 msgstr "Envio de Contribuição"
 
-#: models.py:93
+#: src/colab_gitlab/models.py:93
 msgid "Gitlab Merge Requests"
 msgstr "Envio de Contribuições"
 
-#: models.py:121
+#: src/colab_gitlab/models.py:121
 msgid "Gitlab Issue"
 msgstr "Tíquete"
 
-#: models.py:122
+#: src/colab_gitlab/models.py:122
 msgid "Gitlab Issues"
 msgstr "Tíquetes"
 
-#: models.py:177 models.py:178
+#: src/colab_gitlab/models.py:177 src/colab_gitlab/models.py:178
 msgid "Gitlab Comments"
 msgstr "Comentários"
 
-#: password_validators.py:8
+#: src/colab_gitlab/password_validators.py:8
 msgid "Password must have at least 8 characters."
 msgstr "A senha deve ter pelo menos 8 caracteres."
 
-#: templates/search/comment_search_preview.html:8
-#: templates/search/issue_search_preview.html:7
-#: templates/search/merge_request_search_preview.html:8
-#: templates/search/project_search_preview.html:11
+#: src/colab_gitlab/templates/dashboard/comment_search_preview.html:13
+#: src/colab_gitlab/templates/dashboard/issue_search_preview.html:13
+#: src/colab_gitlab/templates/dashboard/merge_request_search_preview.html:13
+msgid "ago"
+msgstr ""
+
+#: src/colab_gitlab/templates/dashboard/merge_request_search_preview.html:12
+msgid "From"
+msgstr ""
+
+#: src/colab_gitlab/templates/dashboard/merge_request_search_preview.html:12
+msgid "to"
+msgstr ""
+
+#: src/colab_gitlab/templates/search/project_search_preview.html:13
+msgid "Since"
+msgstr ""
+
+#: src/colab_gitlab/templates/search/project_search_preview.html:14
 msgid "Registred in"
 msgstr "Registrado em"
 
-#: templates/search/comment_search_preview.html:8
-#: templates/search/issue_search_preview.html:7
-#: templates/search/merge_request_search_preview.html:8
-#: templates/search/project_search_preview.html:11
+#: src/colab_gitlab/templates/search/project_search_preview.html:14
 msgid "Code"
 msgstr "Código"
 
+#: src/colab_gitlab/widgets/profile/profile.py:11
 msgid "Development"
 msgstr "Desenvolvimento"
 
-msgid "Public Projects"
-msgstr "Projetos Públicos"
+#: src/colab_gitlab/widgets/profile/profile.py:46
+msgid "Something went wrong with gitlab authentication, please relog."
+msgstr "Falha na autenticação do gitlab, porfavor relogue."
 
-msgid "New Project"
-msgstr "Novo Projeto"
+#~ msgid "Public Projects"
+#~ msgstr "Projetos Públicos"
+
+#~ msgid "New Project"
+#~ msgstr "Novo Projeto"


### PR DESCRIPTION
Profile page with gitlab_profile widget breaks with KeyError '__gitlab_session'

This happens when the user is already logged in colab previous to the automated login feature, thus it may happen that the user is logged in colab but not gitlab, missing the gitlab_session token.

Note: with the automated login, when creating a new user and login in colab, if gitlab is offline, colab can't login. Creating a user, the user is created but the page is stuck in loading. Same with noosfero probably. if any if these are offline, dispatch is stuck with no timeout set.